### PR TITLE
updated polling message. Added reset list functionality for testing

### DIFF
--- a/app/versions/main-ui/v10/routes.js
+++ b/app/versions/main-ui/v10/routes.js
@@ -40,8 +40,8 @@ const reports = [{
   query: '?filters.date.start=' + getTodayMinusDays(1) + '&filters.date.end=' + getTodayMinusDays(0) + '&filters.direction=out&filters.type=transfer&printable=false'
 }]
 
-const recentlyViewed = []
-const requested = []
+let recentlyViewed = []
+let requested = []
 
 router.get('', [handlers.configureCurrentUrl, handlers.configureNavigation, function (req, res) {
   res.render(`main-ui/${version}/views/home`, {
@@ -232,6 +232,12 @@ const removeFromRecent = (data) => {
 router.post('/removeFromRecent/', (req, res) => {
   const data = JSON.parse(req.body.data)
   removeFromRecent(data)
+  res.end()
+})
+
+router.post('/resetLists/', (req, res) => {
+  recentlyViewed = []
+  requested = []
   res.end()
 })
 

--- a/app/versions/main-ui/v10/views/home.html
+++ b/app/versions/main-ui/v10/views/home.html
@@ -36,6 +36,10 @@
   {{ appCardGroupRecent(reports) }}
 </div>
 
+{% if (recentlyViewed.length > 0) or requested.length > 0 %}
+<div><a id="resetLists">Reset Lists</a><div>
+{% endif %}
+
   <script>
     const baseUrl = window.location.origin
     let statusUpdateInterval = setInterval( async () => {
@@ -61,5 +65,14 @@
         location.reload() 
       }
     }
+    const resetLists = async () => {
+      const res = await axios.post(`${baseUrl}/main-ui/v10/resetLists/`, {})
+      .catch(function (error) {
+        console.log(error)
+      });
+      location.reload()
+    }
+
+    document.getElementById("resetLists").addEventListener("click", resetLists);
   </script>
 {% endblock %}

--- a/app/versions/main-ui/v10/views/list-polling.html
+++ b/app/versions/main-ui/v10/views/list-polling.html
@@ -39,7 +39,7 @@
     </ul>
 
     {{ govukInsetText({
-      html: "<p>It can take up to 24hrs to generate a report.</p> <p>You can close and revisit this page at anytime, or navigate to the <a href='/main-ui/v10/'>homepage</a> to check on its status or your report</p>"
+      html: "<p>It can take up to 10 mins to generate a report.</p> <p>You can close and revisit this page at anytime, or navigate to the <a href='/main-ui/v10/'>homepage</a> to check on its status or your report</p>"
     }) }}
 
 


### PR DESCRIPTION
Updates to Async Report Loading:

- messaging while polling - 10 mins, not 24 hours
- Implemented reset button on the homepage to reset lists. For testing